### PR TITLE
Fix null check exception on a disposed ticker

### DIFF
--- a/lib/view/mesh.dart
+++ b/lib/view/mesh.dart
@@ -40,8 +40,10 @@ class _BackgroundMeshState extends State<BackgroundMesh>
   Future<void> startAnimations() async {
     _firstController.repeat();
     await Future.delayed(const Duration(milliseconds: 1000));
+    if (!mounted) return;
     _secondController.repeat();
     await Future.delayed(const Duration(milliseconds: 1000));
+    if (!mounted) return;
     _thirdController.repeat();
   }
 


### PR DESCRIPTION
Full stack:
>animation_controller.dart in AnimationController.stop at line 866 within flutter
>animation_controller.dart in AnimationController.repeat at line 745 within flutter
>mesh.dart in _BackgroundMeshState.startAnimations at line 45 within reward_popup